### PR TITLE
extract date format to global variable to allow customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,8 @@ Set the directory using the `notes_dir` variable:
 
     let g:notes_dir = $HOME . "/some/other/directory"
 
+Set the date format for the names of the files using the `vim_notes_date_format` variable:
+
+    let g:vim_notes_date_format = "%d-%m-%Y-%A"
+
+The format should be the accepted by the `strftime()` function.

--- a/plugin/notes.vim
+++ b/plugin/notes.vim
@@ -25,16 +25,17 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 let g:notes_dir = get(g:, 'notes_dir', $HOME . "/notes")
+let g:vim_notes_date_format = get(g:, 'vim_notes_date_format', "%d-%m-%Y")
 
 function! s:NotesEntry()
   if !isdirectory(g:notes_dir)
       call mkdir(g:notes_dir, "p")
   endif
 
-  execute "edit " . g:notes_dir . "/" . strftime("%d-%m-%Y") . ".md"
+  execute "edit " . g:notes_dir . "/" . strftime(g:vim_notes_date_format) . ".md"
 endfunction
 
-command! Notes call s:NotesEntry()<CR>
+command! Notes call s:NotesEntry()
 
-let &cpo = s:save_cpo 
+let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Hey, first of all: cool plugin. This is something that I was thinking of doing myself, to clean up my workflow a little bit and this does exactly what I need.

I was thinking of changing the name of the files that are being generated for each day, to make them more readable manually by including the week day.
Instead of doing that just for myself or trying to impose it on you, I thought that it may be of use extracting the date format to a global variable that users may change themselves.

So, my use case would be accomplished by setting this in my config:

```vim
let g:vim_notes_date_format = "+%d-%m-%Y-%A"
```
